### PR TITLE
对 `main/Compiler.py` 进行了一些小修补, 使其可以在类Unix平台正确连接目录

### DIFF
--- a/main/Compiler.py
+++ b/main/Compiler.py
@@ -1,12 +1,17 @@
 from SA import sematicAnalyzer
 from time import time
-import sys
-import os
+from sys import argv
+from os import path
 
 
-start = time()
-if len(sys.argv) == 1:
-    sematicAnalyzer(os.getcwd()+r'\test.js')
-else:
-    sematicAnalyzer(sys.argv[1])
-print('\n程序用时', time()-start, 's')
+PROJECT_ROOT = path.split(path.split(__file__)[0])[0]
+
+
+if __name__ == '__main__':
+    start = time()
+    if len(argv) == 1:
+        sematicAnalyzer(path.join(PROJECT_ROOT, 'test.js'))
+    else:
+        sematicAnalyzer(argv[1])
+    stop = time()
+    print('\n程序用时', stop-start, 's')


### PR DESCRIPTION
与不受工作目录影响的连接路径(使用示例时)
并且添加了`main`使其被导入时不会被执行